### PR TITLE
Implement InsertAt and IndexOf (#2, #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Local Claude settings
+.claude/

--- a/LaquaiLib.Collections.HashList.Tests/ConcurrentHashListTests.cs
+++ b/LaquaiLib.Collections.HashList.Tests/ConcurrentHashListTests.cs
@@ -138,6 +138,82 @@ public class ConcurrentHashListTests
     }
     #endregion
 
+    #region InsertAt
+    [Fact]
+    public void InsertAt_DefaultListBacked_InsertsCorrectly()
+    {
+        using var list = (ConcurrentHashList<int>)HashList.CreateConcurrent<int>();
+        list.Add(1);
+        list.Add(3);
+        Assert.True(list.InsertAt(1, 2));
+        Assert.Equal(1, list[0]);
+        Assert.Equal(2, list[1]);
+        Assert.Equal(3, list[2]);
+    }
+
+    [Fact]
+    public void InsertAt_LinkedListBacked_InsertsCorrectly()
+    {
+        using var list = (ConcurrentHashList<int>)HashList.CreateConcurrent<int>(optimizeForRemove: true);
+        list.Add(1);
+        list.Add(3);
+        Assert.True(list.InsertAt(1, 2));
+        Assert.Equal(1, list[0]);
+        Assert.Equal(2, list[1]);
+        Assert.Equal(3, list[2]);
+    }
+
+    [Fact]
+    public void InsertAt_DuplicateItem_ReturnsFalse()
+    {
+        using var list = (ConcurrentHashList<int>)HashList.CreateConcurrent<int>();
+        list.Add(1);
+        Assert.False(list.InsertAt(0, 1));
+    }
+
+    [Fact]
+    public void InsertAt_OutOfRange_Throws()
+    {
+        using var list = (ConcurrentHashList<int>)HashList.CreateConcurrent<int>();
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.InsertAt(-1, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.InsertAt(1, 1));
+    }
+    #endregion
+
+    #region IndexOf
+    [Fact]
+    public void IndexOf_DefaultListBacked_ReturnsCorrectIndex()
+    {
+        using var list = (ConcurrentHashList<int>)HashList.CreateConcurrent<int>();
+        list.Add(10);
+        list.Add(20);
+        list.Add(30);
+        Assert.Equal(0, list.IndexOf(10));
+        Assert.Equal(1, list.IndexOf(20));
+        Assert.Equal(2, list.IndexOf(30));
+    }
+
+    [Fact]
+    public void IndexOf_LinkedListBacked_ReturnsCorrectIndex()
+    {
+        using var list = (ConcurrentHashList<int>)HashList.CreateConcurrent<int>(optimizeForRemove: true);
+        list.Add(10);
+        list.Add(20);
+        list.Add(30);
+        Assert.Equal(0, list.IndexOf(10));
+        Assert.Equal(1, list.IndexOf(20));
+        Assert.Equal(2, list.IndexOf(30));
+    }
+
+    [Fact]
+    public void IndexOf_NonExistingItem_ReturnsNegativeOne()
+    {
+        using var list = (ConcurrentHashList<int>)HashList.CreateConcurrent<int>();
+        list.Add(1);
+        Assert.Equal(-1, list.IndexOf(99));
+    }
+    #endregion
+
     #region Enumeration (snapshot behavior)
     [Fact]
     public void GetEnumerator_ReturnsSnapshot()

--- a/LaquaiLib.Collections.HashList.Tests/DefaultListHashListTests.cs
+++ b/LaquaiLib.Collections.HashList.Tests/DefaultListHashListTests.cs
@@ -395,6 +395,195 @@ public class DefaultListHashListTests
     }
     #endregion
 
+    #region InsertAt
+    [Fact]
+    public void InsertAt_Beginning_ShiftsElements()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.True(list.InsertAt(0, 0));
+        Assert.Equal(0, list[0]);
+        Assert.Equal(1, list[1]);
+        Assert.Equal(2, list[2]);
+        Assert.Equal(3, list.Count);
+    }
+
+    [Fact]
+    public void InsertAt_Middle_ShiftsElements()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(3);
+        Assert.True(list.InsertAt(1, 2));
+        Assert.Equal(1, list[0]);
+        Assert.Equal(2, list[1]);
+        Assert.Equal(3, list[2]);
+    }
+
+    [Fact]
+    public void InsertAt_End_AppendsElement()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.True(list.InsertAt(2, 3));
+        Assert.Equal(1, list[0]);
+        Assert.Equal(2, list[1]);
+        Assert.Equal(3, list[2]);
+    }
+
+    [Fact]
+    public void InsertAt_EmptyList_AtZero_Works()
+    {
+        var list = Create<int>();
+        Assert.True(list.InsertAt(0, 42));
+        Assert.Equal(1, list.Count);
+        Assert.Equal(42, list[0]);
+    }
+
+    [Fact]
+    public void InsertAt_DuplicateItem_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        Assert.False(list.InsertAt(0, 1));
+        Assert.Equal(1, list.Count);
+    }
+
+    [Fact]
+    public void InsertAt_NegativeIndex_Throws()
+    {
+        var list = Create<int>();
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.InsertAt(-1, 1));
+    }
+
+    [Fact]
+    public void InsertAt_IndexGreaterThanCount_Throws()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.InsertAt(2, 2));
+    }
+
+    [Fact]
+    public void InsertAt_DuplicateItem_DoesNotThrowForOutOfRangeIndex()
+    {
+        // When item is a duplicate, the duplicate check happens after the range check,
+        // so an out-of-range index with a duplicate item should still throw
+        var list = Create<int>();
+        list.Add(1);
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.InsertAt(5, 1));
+    }
+
+    [Fact]
+    public void InsertAt_MaintainsContainsConsistency()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(3);
+        list.InsertAt(1, 2);
+        Assert.True(list.Contains(1));
+        Assert.True(list.Contains(2));
+        Assert.True(list.Contains(3));
+    }
+
+    [Fact]
+    public void InsertAt_ThenRemove_Works()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(3);
+        list.InsertAt(1, 2);
+        list.Remove(2);
+        Assert.Equal(2, list.Count);
+        Assert.Equal(1, list[0]);
+        Assert.Equal(3, list[1]);
+    }
+    #endregion
+
+    #region IndexOf
+    [Fact]
+    public void IndexOf_ExistingItem_ReturnsCorrectIndex()
+    {
+        var list = Create<int>();
+        list.Add(10);
+        list.Add(20);
+        list.Add(30);
+        Assert.Equal(0, list.IndexOf(10));
+        Assert.Equal(1, list.IndexOf(20));
+        Assert.Equal(2, list.IndexOf(30));
+    }
+
+    [Fact]
+    public void IndexOf_NonExistingItem_ReturnsNegativeOne()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        Assert.Equal(-1, list.IndexOf(99));
+    }
+
+    [Fact]
+    public void IndexOf_EmptyList_ReturnsNegativeOne()
+    {
+        var list = Create<int>();
+        Assert.Equal(-1, list.IndexOf(1));
+    }
+
+    [Fact]
+    public void IndexOf_AfterRemoval_ReturnsNegativeOne()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Remove(1);
+        Assert.Equal(-1, list.IndexOf(1));
+    }
+
+    [Fact]
+    public void IndexOf_AfterRemoval_UpdatesIndices()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        list.Remove(1);
+        Assert.Equal(0, list.IndexOf(2));
+        Assert.Equal(1, list.IndexOf(3));
+    }
+
+    [Fact]
+    public void IndexOf_WithCustomComparer_UsesComparer()
+    {
+        var list = HashList.Create<string>(StringComparer.OrdinalIgnoreCase);
+        list.Add("Hello");
+        list.Add("World");
+        Assert.Equal(0, list.IndexOf("hello"));
+        Assert.Equal(1, list.IndexOf("WORLD"));
+    }
+
+    [Fact]
+    public void IndexOf_AfterInsertAt_ReturnsCorrectIndex()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(3);
+        list.InsertAt(1, 2);
+        Assert.Equal(0, list.IndexOf(1));
+        Assert.Equal(1, list.IndexOf(2));
+        Assert.Equal(2, list.IndexOf(3));
+    }
+
+    [Fact]
+    public void IndexOf_NullItem_WorksForReferenceType()
+    {
+        var list = Create<string>();
+        list.Add("a");
+        list.Add(null);
+        list.Add("b");
+        Assert.Equal(1, list.IndexOf(null));
+    }
+    #endregion
+
     #region Large collection
     [Fact]
     public void LargeCollection_MaintainsInsertionOrder()

--- a/LaquaiLib.Collections.HashList.Tests/DefaultListHashListTests.cs
+++ b/LaquaiLib.Collections.HashList.Tests/DefaultListHashListTests.cs
@@ -42,7 +42,7 @@ public class DefaultListHashListTests
         var list = Create<string>();
         Assert.True(list.Add(null));
         Assert.False(list.Add(null));
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
 
     [Fact]
@@ -51,7 +51,7 @@ public class DefaultListHashListTests
         ICollection<int> list = Create<int>();
         list.Add(1);
         list.Add(1); // duplicate via ICollection doesn't throw, just silently fails
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
     #endregion
 
@@ -78,7 +78,7 @@ public class DefaultListHashListTests
         list.Add(1);
         list.Add(2);
         list.Remove(1);
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class DefaultListHashListTests
         var list = Create<int>();
         list.Add(1);
         list.Remove(1);
-        Assert.False(list.Contains(1));
+        Assert.DoesNotContain(1, list);
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public class DefaultListHashListTests
         list.Add(1);
         list.Remove(1);
         Assert.True(list.Add(1));
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
 
     [Fact]
@@ -119,14 +119,14 @@ public class DefaultListHashListTests
     {
         var list = Create<int>();
         list.Add(42);
-        Assert.True(list.Contains(42));
+        Assert.Contains(42, list);
     }
 
     [Fact]
     public void Contains_NonExistingItem_ReturnsFalse()
     {
         var list = Create<int>();
-        Assert.False(list.Contains(42));
+        Assert.DoesNotContain(42, list);
     }
 
     [Fact]
@@ -135,7 +135,7 @@ public class DefaultListHashListTests
         var list = Create<int>();
         list.Add(1);
         list.Clear();
-        Assert.False(list.Contains(1));
+        Assert.DoesNotContain(1, list);
     }
     #endregion
 
@@ -147,7 +147,7 @@ public class DefaultListHashListTests
         list.Add(1);
         list.Add(2);
         list.Clear();
-        Assert.Equal(0, list.Count);
+        Assert.Empty(list);
     }
 
     [Fact]
@@ -155,7 +155,7 @@ public class DefaultListHashListTests
     {
         var list = Create<int>();
         list.Clear();
-        Assert.Equal(0, list.Count);
+        Assert.Empty(list);
     }
 
     [Fact]
@@ -173,7 +173,7 @@ public class DefaultListHashListTests
     public void Count_EmptyList_ReturnsZero()
     {
         var list = Create<int>();
-        Assert.Equal(0, list.Count);
+        Assert.Empty(list);
     }
 
     [Fact]
@@ -192,7 +192,7 @@ public class DefaultListHashListTests
         var list = Create<int>();
         list.Add(1);
         list.Add(1);
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
     #endregion
 
@@ -346,7 +346,7 @@ public class DefaultListHashListTests
         var list = HashList.Create<string>(StringComparer.OrdinalIgnoreCase);
         list.Add("Hello");
         Assert.False(list.Add("hello"));
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
 
     [Fact]
@@ -354,8 +354,10 @@ public class DefaultListHashListTests
     {
         var list = HashList.Create<string>(StringComparer.OrdinalIgnoreCase);
         list.Add("Hello");
+#pragma warning disable xUnit2017 // Intentionally testing HashList.Contains with custom comparer
         Assert.True(list.Contains("hello"));
         Assert.True(list.Contains("HELLO"));
+#pragma warning restore xUnit2017
     }
 
     [Fact]
@@ -364,7 +366,7 @@ public class DefaultListHashListTests
         var list = HashList.Create<string>(StringComparer.OrdinalIgnoreCase);
         list.Add("Hello");
         Assert.True(list.Remove("hello"));
-        Assert.Equal(0, list.Count);
+        Assert.Empty(list);
     }
     #endregion
 
@@ -373,9 +375,9 @@ public class DefaultListHashListTests
     public void Create_WithCapacity_DoesNotAffectBehavior()
     {
         var list = HashList.Create<int>(100);
-        Assert.Equal(0, list.Count);
+        Assert.Empty(list);
         list.Add(1);
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
 
     [Fact]
@@ -383,7 +385,7 @@ public class DefaultListHashListTests
     {
         var list = HashList.Create<int>(0);
         list.Add(1);
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
 
     [Fact]
@@ -391,7 +393,7 @@ public class DefaultListHashListTests
     {
         var list = HashList.Create<int>(-1);
         list.Add(1);
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
     #endregion
 
@@ -438,7 +440,7 @@ public class DefaultListHashListTests
     {
         var list = Create<int>();
         Assert.True(list.InsertAt(0, 42));
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
         Assert.Equal(42, list[0]);
     }
 
@@ -448,7 +450,7 @@ public class DefaultListHashListTests
         var list = Create<int>();
         list.Add(1);
         Assert.False(list.InsertAt(0, 1));
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
 
     [Fact]
@@ -483,9 +485,9 @@ public class DefaultListHashListTests
         list.Add(1);
         list.Add(3);
         list.InsertAt(1, 2);
-        Assert.True(list.Contains(1));
-        Assert.True(list.Contains(2));
-        Assert.True(list.Contains(3));
+        Assert.Contains(1, list);
+        Assert.Contains(2, list);
+        Assert.Contains(3, list);
     }
 
     [Fact]

--- a/LaquaiLib.Collections.HashList.Tests/DefaultListHashListTests.cs
+++ b/LaquaiLib.Collections.HashList.Tests/DefaultListHashListTests.cs
@@ -469,7 +469,7 @@ public class DefaultListHashListTests
     }
 
     [Fact]
-    public void InsertAt_DuplicateItem_DoesNotThrowForOutOfRangeIndex()
+    public void InsertAt_DuplicateItem_ThrowsArgumentOutOfRangeForOutOfRangeIndex()
     {
         // When item is a duplicate, the duplicate check happens after the range check,
         // so an out-of-range index with a duplicate item should still throw
@@ -583,6 +583,266 @@ public class DefaultListHashListTests
         list.Add(null);
         list.Add("b");
         Assert.Equal(1, list.IndexOf(null));
+    }
+    #endregion
+
+    #region IReadOnlySet
+    [Fact]
+    public void IsSubsetOf_EmptySet_ReturnsTrueForAny()
+    {
+        var list = Create<int>();
+        Assert.True(list.IsSubsetOf(new[] { 1, 2, 3 }));
+        Assert.True(list.IsSubsetOf(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void IsSubsetOf_ProperSubset_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.True(list.IsSubsetOf(new[] { 1, 2, 3 }));
+    }
+
+    [Fact]
+    public void IsSubsetOf_EqualSets_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.True(list.IsSubsetOf(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void IsSubsetOf_Superset_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        Assert.False(list.IsSubsetOf(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void IsProperSubsetOf_EmptySet_NonEmptyOther_ReturnsTrue()
+    {
+        var list = Create<int>();
+        Assert.True(list.IsProperSubsetOf(new[] { 1 }));
+    }
+
+    [Fact]
+    public void IsProperSubsetOf_EmptySet_EmptyOther_ReturnsFalse()
+    {
+        var list = Create<int>();
+        Assert.False(list.IsProperSubsetOf(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void IsProperSubsetOf_ProperSubset_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.True(list.IsProperSubsetOf(new[] { 1, 2, 3 }));
+    }
+
+    [Fact]
+    public void IsProperSubsetOf_EqualSets_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.False(list.IsProperSubsetOf(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void IsProperSubsetOf_Superset_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        Assert.False(list.IsProperSubsetOf(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void IsSupersetOf_EmptyOther_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        Assert.True(list.IsSupersetOf(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void IsSupersetOf_EqualSets_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.True(list.IsSupersetOf(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void IsSupersetOf_ProperSuperset_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        Assert.True(list.IsSupersetOf(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void IsSupersetOf_SubsetOfOther_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.False(list.IsSupersetOf(new[] { 1, 2, 3 }));
+    }
+
+    [Fact]
+    public void IsProperSupersetOf_EmptySet_ReturnsFalse()
+    {
+        var list = Create<int>();
+        Assert.False(list.IsProperSupersetOf(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void IsProperSupersetOf_NonEmptySet_SupersetOfEmptyOther_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        Assert.True(list.IsProperSupersetOf(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void IsProperSupersetOf_ProperSuperset_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        Assert.True(list.IsProperSupersetOf(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void IsProperSupersetOf_EqualSets_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.False(list.IsProperSupersetOf(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void IsProperSupersetOf_SubsetOfOther_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.False(list.IsProperSupersetOf(new[] { 1, 2, 3 }));
+    }
+
+    [Fact]
+    public void Overlaps_WithCommonElement_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.True(list.Overlaps(new[] { 2, 3 }));
+    }
+
+    [Fact]
+    public void Overlaps_NoCommonElements_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.False(list.Overlaps(new[] { 3, 4 }));
+    }
+
+    [Fact]
+    public void Overlaps_EmptyList_ReturnsFalse()
+    {
+        var list = Create<int>();
+        Assert.False(list.Overlaps(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void Overlaps_EmptyOther_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        Assert.False(list.Overlaps(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void SetEquals_EqualSets_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        Assert.True(list.SetEquals(new[] { 1, 2, 3 }));
+    }
+
+    [Fact]
+    public void SetEquals_DifferentOrder_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        Assert.True(list.SetEquals(new[] { 3, 1, 2 }));
+    }
+
+    [Fact]
+    public void SetEquals_DifferentElements_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.False(list.SetEquals(new[] { 1, 3 }));
+    }
+
+    [Fact]
+    public void SetEquals_DifferentSizes_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.False(list.SetEquals(new[] { 1, 2, 3 }));
+    }
+
+    [Fact]
+    public void SetEquals_EmptyBoth_ReturnsTrue()
+    {
+        var list = Create<int>();
+        Assert.True(list.SetEquals(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void SetEquals_WithDuplicatesInOther_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.True(list.SetEquals(new[] { 1, 1, 2, 2 }));
+    }
+
+    [Fact]
+    public void IReadOnlySet_Interface_Works()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        IReadOnlySet<int> roSet = list;
+        Assert.True(roSet.IsSubsetOf(new[] { 1, 2, 3, 4 }));
+        Assert.True(roSet.IsSupersetOf(new[] { 1, 2 }));
+        Assert.True(roSet.SetEquals(new[] { 1, 2, 3 }));
+        Assert.True(roSet.Overlaps(new[] { 3, 4 }));
     }
     #endregion
 

--- a/LaquaiLib.Collections.HashList.Tests/FactoryAndOptionsTests.cs
+++ b/LaquaiLib.Collections.HashList.Tests/FactoryAndOptionsTests.cs
@@ -2,6 +2,10 @@ using Xunit;
 
 using LaquaiLib.Collections;
 
+// All Assert.True(list.Contains(...)) calls in this file intentionally test
+// that factory methods correctly pass custom comparers to the underlying HashList.
+#pragma warning disable xUnit2017
+
 namespace LaquaiLib.Collections.Tests;
 
 /// <summary>
@@ -23,7 +27,7 @@ public class FactoryAndOptionsTests
     {
         var list = HashList.Create<int>(16);
         list.Add(1);
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
 
     [Fact]
@@ -65,7 +69,7 @@ public class FactoryAndOptionsTests
     {
         var list = HashList.Create<int>(32, optimizeForRemove: true);
         list.Add(1);
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
 
     [Fact]
@@ -82,7 +86,7 @@ public class FactoryAndOptionsTests
         var list = HashList.Create<string>(16, StringComparer.OrdinalIgnoreCase, optimizeForRemove: true);
         list.Add("Test");
         Assert.True(list.Contains("TEST"));
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
 
     [Fact]
@@ -120,7 +124,7 @@ public class FactoryAndOptionsTests
         var list = HashList.CreateConcurrent<int>(16);
         Assert.IsType<ConcurrentHashList<int>>(list);
         list.Add(1);
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
 
     [Fact]

--- a/LaquaiLib.Collections.HashList.Tests/LinkedListHashListTests.cs
+++ b/LaquaiLib.Collections.HashList.Tests/LinkedListHashListTests.cs
@@ -42,7 +42,7 @@ public class LinkedListHashListTests
         ICollection<int> list = Create<int>();
         list.Add(1);
         list.Add(1);
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
     #endregion
 
@@ -69,7 +69,7 @@ public class LinkedListHashListTests
         list.Add(1);
         list.Add(2);
         list.Remove(1);
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
 
     [Fact]
@@ -78,7 +78,7 @@ public class LinkedListHashListTests
         var list = Create<int>();
         list.Add(1);
         list.Remove(1);
-        Assert.False(list.Contains(1));
+        Assert.DoesNotContain(1, list);
     }
 
     [Fact]
@@ -88,7 +88,7 @@ public class LinkedListHashListTests
         list.Add(1);
         list.Remove(1);
         Assert.True(list.Add(1));
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
 
     [Fact]
@@ -134,14 +134,14 @@ public class LinkedListHashListTests
     {
         var list = Create<int>();
         list.Add(42);
-        Assert.True(list.Contains(42));
+        Assert.Contains(42, list);
     }
 
     [Fact]
     public void Contains_NonExistingItem_ReturnsFalse()
     {
         var list = Create<int>();
-        Assert.False(list.Contains(42));
+        Assert.DoesNotContain(42, list);
     }
 
     [Fact]
@@ -150,7 +150,7 @@ public class LinkedListHashListTests
         var list = Create<int>();
         list.Add(1);
         list.Clear();
-        Assert.False(list.Contains(1));
+        Assert.DoesNotContain(1, list);
     }
     #endregion
 
@@ -162,7 +162,7 @@ public class LinkedListHashListTests
         list.Add(1);
         list.Add(2);
         list.Clear();
-        Assert.Equal(0, list.Count);
+        Assert.Empty(list);
     }
 
     [Fact]
@@ -180,7 +180,7 @@ public class LinkedListHashListTests
     public void Count_EmptyList_ReturnsZero()
     {
         var list = Create<int>();
-        Assert.Equal(0, list.Count);
+        Assert.Empty(list);
     }
 
     [Fact]
@@ -189,7 +189,7 @@ public class LinkedListHashListTests
         var list = Create<int>();
         list.Add(1);
         list.Add(1);
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
     #endregion
 
@@ -343,7 +343,7 @@ public class LinkedListHashListTests
         var list = HashList.Create<string>(StringComparer.OrdinalIgnoreCase, optimizeForRemove: true);
         list.Add("Hello");
         Assert.False(list.Add("hello"));
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
 
     [Fact]
@@ -351,7 +351,9 @@ public class LinkedListHashListTests
     {
         var list = HashList.Create<string>(StringComparer.OrdinalIgnoreCase, optimizeForRemove: true);
         list.Add("Hello");
+#pragma warning disable xUnit2017 // Intentionally testing HashList.Contains with custom comparer
         Assert.True(list.Contains("hello"));
+#pragma warning restore xUnit2017
     }
 
     [Fact]
@@ -360,7 +362,7 @@ public class LinkedListHashListTests
         var list = HashList.Create<string>(StringComparer.OrdinalIgnoreCase, optimizeForRemove: true);
         list.Add("Hello");
         Assert.True(list.Remove("hello"));
-        Assert.Equal(0, list.Count);
+        Assert.Empty(list);
     }
     #endregion
 
@@ -407,7 +409,7 @@ public class LinkedListHashListTests
     {
         var list = Create<int>();
         Assert.True(list.InsertAt(0, 42));
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
         Assert.Equal(42, list[0]);
     }
 
@@ -417,7 +419,7 @@ public class LinkedListHashListTests
         var list = Create<int>();
         list.Add(1);
         Assert.False(list.InsertAt(0, 1));
-        Assert.Equal(1, list.Count);
+        Assert.Single(list);
     }
 
     [Fact]
@@ -450,9 +452,9 @@ public class LinkedListHashListTests
         list.Add(1);
         list.Add(3);
         list.InsertAt(1, 2);
-        Assert.True(list.Contains(1));
-        Assert.True(list.Contains(2));
-        Assert.True(list.Contains(3));
+        Assert.Contains(1, list);
+        Assert.Contains(2, list);
+        Assert.Contains(3, list);
     }
 
     [Fact]

--- a/LaquaiLib.Collections.HashList.Tests/LinkedListHashListTests.cs
+++ b/LaquaiLib.Collections.HashList.Tests/LinkedListHashListTests.cs
@@ -438,7 +438,7 @@ public class LinkedListHashListTests
     }
 
     [Fact]
-    public void InsertAt_DuplicateItem_DoesNotThrowForOutOfRangeIndex()
+    public void InsertAt_DuplicateItem_ThrowsArgumentOutOfRangeForOutOfRangeIndex()
     {
         var list = Create<int>();
         list.Add(1);
@@ -567,6 +567,367 @@ public class LinkedListHashListTests
             list.Add(i);
         for (var i = 0; i < 100; i++)
             Assert.Equal(i, list.IndexOf(i));
+    }
+    #endregion
+
+    #region IReadOnlySet
+    [Fact]
+    public void IsSubsetOf_EmptySet_ReturnsTrueForAny()
+    {
+        var list = Create<int>();
+        Assert.True(list.IsSubsetOf(new[] { 1, 2, 3 }));
+        Assert.True(list.IsSubsetOf(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void IsSubsetOf_ProperSubset_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.True(list.IsSubsetOf(new[] { 1, 2, 3 }));
+    }
+
+    [Fact]
+    public void IsSubsetOf_EqualSets_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.True(list.IsSubsetOf(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void IsSubsetOf_Superset_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        Assert.False(list.IsSubsetOf(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void IsSubsetOf_ViaIReadOnlySet_ReturnsTrue()
+    {
+        // Exercises the IReadOnlySet<T> fast path in LinkedListHashList.IsSubsetOf
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        IReadOnlySet<int> other = new HashSet<int>([1, 2, 3]);
+        Assert.True(list.IsSubsetOf(other));
+    }
+
+    [Fact]
+    public void IsSubsetOf_ViaEnumerable_ReturnsTrue()
+    {
+        // Exercises the IEnumerable<T> fallback path in LinkedListHashList.IsSubsetOf
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        IEnumerable<int> other = new List<int> { 1, 2, 3 };
+        Assert.True(list.IsSubsetOf(other));
+    }
+
+    [Fact]
+    public void IsProperSubsetOf_EmptySet_NonEmptyOther_ReturnsTrue()
+    {
+        var list = Create<int>();
+        Assert.True(list.IsProperSubsetOf(new[] { 1 }));
+    }
+
+    [Fact]
+    public void IsProperSubsetOf_EmptySet_EmptyOther_ReturnsFalse()
+    {
+        var list = Create<int>();
+        Assert.False(list.IsProperSubsetOf(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void IsProperSubsetOf_ProperSubset_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.True(list.IsProperSubsetOf(new[] { 1, 2, 3 }));
+    }
+
+    [Fact]
+    public void IsProperSubsetOf_EqualSets_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.False(list.IsProperSubsetOf(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void IsProperSubsetOf_Superset_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        Assert.False(list.IsProperSubsetOf(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void IsProperSubsetOf_ViaIReadOnlySet_ReturnsTrue()
+    {
+        // Exercises the IReadOnlySet<T> fast path in LinkedListHashList.IsProperSubsetOf
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        IReadOnlySet<int> other = new HashSet<int>([1, 2, 3]);
+        Assert.True(list.IsProperSubsetOf(other));
+    }
+
+    [Fact]
+    public void IsProperSubsetOf_ViaEnumerable_ReturnsTrue()
+    {
+        // Exercises the IEnumerable<T> fallback path in LinkedListHashList.IsProperSubsetOf
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        IEnumerable<int> other = new List<int> { 1, 2, 3 };
+        Assert.True(list.IsProperSubsetOf(other));
+    }
+
+    [Fact]
+    public void IsSupersetOf_EmptyOther_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        Assert.True(list.IsSupersetOf(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void IsSupersetOf_EqualSets_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.True(list.IsSupersetOf(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void IsSupersetOf_ProperSuperset_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        Assert.True(list.IsSupersetOf(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void IsSupersetOf_SubsetOfOther_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.False(list.IsSupersetOf(new[] { 1, 2, 3 }));
+    }
+
+    [Fact]
+    public void IsProperSupersetOf_EmptySet_ReturnsFalse()
+    {
+        var list = Create<int>();
+        Assert.False(list.IsProperSupersetOf(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void IsProperSupersetOf_NonEmptySet_SupersetOfEmptyOther_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        Assert.True(list.IsProperSupersetOf(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void IsProperSupersetOf_ProperSuperset_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        Assert.True(list.IsProperSupersetOf(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void IsProperSupersetOf_EqualSets_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.False(list.IsProperSupersetOf(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void IsProperSupersetOf_SubsetOfOther_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.False(list.IsProperSupersetOf(new[] { 1, 2, 3 }));
+    }
+
+    [Fact]
+    public void IsProperSupersetOf_ViaIReadOnlySet_ReturnsTrue()
+    {
+        // Exercises the IReadOnlySet<T> fast path in LinkedListHashList.IsProperSupersetOf
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        IReadOnlySet<int> other = new HashSet<int>([1, 2]);
+        Assert.True(list.IsProperSupersetOf(other));
+    }
+
+    [Fact]
+    public void IsProperSupersetOf_ViaEnumerable_ReturnsTrue()
+    {
+        // Exercises the IEnumerable<T> fallback path in LinkedListHashList.IsProperSupersetOf
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        IEnumerable<int> other = new List<int> { 1, 2 };
+        Assert.True(list.IsProperSupersetOf(other));
+    }
+
+    [Fact]
+    public void IsProperSupersetOf_ViaEnumerable_WithNonMember_ReturnsFalse()
+    {
+        // Exercises the early-return branch in the IEnumerable<T> fallback of IsProperSupersetOf
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        IEnumerable<int> other = new List<int> { 1, 99 };
+        Assert.False(list.IsProperSupersetOf(other));
+    }
+
+    [Fact]
+    public void Overlaps_WithCommonElement_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.True(list.Overlaps(new[] { 2, 3 }));
+    }
+
+    [Fact]
+    public void Overlaps_NoCommonElements_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.False(list.Overlaps(new[] { 3, 4 }));
+    }
+
+    [Fact]
+    public void Overlaps_EmptyList_ReturnsFalse()
+    {
+        var list = Create<int>();
+        Assert.False(list.Overlaps(new[] { 1, 2 }));
+    }
+
+    [Fact]
+    public void Overlaps_EmptyOther_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        Assert.False(list.Overlaps(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void SetEquals_EqualSets_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        Assert.True(list.SetEquals(new[] { 1, 2, 3 }));
+    }
+
+    [Fact]
+    public void SetEquals_DifferentOrder_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        Assert.True(list.SetEquals(new[] { 3, 1, 2 }));
+    }
+
+    [Fact]
+    public void SetEquals_DifferentElements_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.False(list.SetEquals(new[] { 1, 3 }));
+    }
+
+    [Fact]
+    public void SetEquals_DifferentSizes_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.False(list.SetEquals(new[] { 1, 2, 3 }));
+    }
+
+    [Fact]
+    public void SetEquals_EmptyBoth_ReturnsTrue()
+    {
+        var list = Create<int>();
+        Assert.True(list.SetEquals(Array.Empty<int>()));
+    }
+
+    [Fact]
+    public void SetEquals_WithDuplicatesInOther_ReturnsTrue()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.True(list.SetEquals(new[] { 1, 1, 2, 2 }));
+    }
+
+    [Fact]
+    public void SetEquals_ViaIReadOnlySet_ReturnsTrue()
+    {
+        // Exercises the IReadOnlySet<T> fast path in LinkedListHashList.SetEquals
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        IReadOnlySet<int> other = new HashSet<int>([1, 2]);
+        Assert.True(list.SetEquals(other));
+    }
+
+    [Fact]
+    public void SetEquals_ViaEnumerable_ReturnsTrue()
+    {
+        // Exercises the IEnumerable<T> fallback path in LinkedListHashList.SetEquals
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        IEnumerable<int> other = new List<int> { 1, 2 };
+        Assert.True(list.SetEquals(other));
+    }
+
+    [Fact]
+    public void IReadOnlySet_Interface_Works()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        IReadOnlySet<int> roSet = list;
+        Assert.True(roSet.IsSubsetOf(new[] { 1, 2, 3, 4 }));
+        Assert.True(roSet.IsSupersetOf(new[] { 1, 2 }));
+        Assert.True(roSet.SetEquals(new[] { 1, 2, 3 }));
+        Assert.True(roSet.Overlaps(new[] { 3, 4 }));
     }
     #endregion
 

--- a/LaquaiLib.Collections.HashList.Tests/LinkedListHashListTests.cs
+++ b/LaquaiLib.Collections.HashList.Tests/LinkedListHashListTests.cs
@@ -364,6 +364,210 @@ public class LinkedListHashListTests
     }
     #endregion
 
+    #region InsertAt
+    [Fact]
+    public void InsertAt_Beginning_ShiftsElements()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.True(list.InsertAt(0, 0));
+        Assert.Equal(0, list[0]);
+        Assert.Equal(1, list[1]);
+        Assert.Equal(2, list[2]);
+        Assert.Equal(3, list.Count);
+    }
+
+    [Fact]
+    public void InsertAt_Middle_ShiftsElements()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(3);
+        Assert.True(list.InsertAt(1, 2));
+        Assert.Equal(1, list[0]);
+        Assert.Equal(2, list[1]);
+        Assert.Equal(3, list[2]);
+    }
+
+    [Fact]
+    public void InsertAt_End_AppendsElement()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        Assert.True(list.InsertAt(2, 3));
+        Assert.Equal(1, list[0]);
+        Assert.Equal(2, list[1]);
+        Assert.Equal(3, list[2]);
+    }
+
+    [Fact]
+    public void InsertAt_EmptyList_AtZero_Works()
+    {
+        var list = Create<int>();
+        Assert.True(list.InsertAt(0, 42));
+        Assert.Equal(1, list.Count);
+        Assert.Equal(42, list[0]);
+    }
+
+    [Fact]
+    public void InsertAt_DuplicateItem_ReturnsFalse()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        Assert.False(list.InsertAt(0, 1));
+        Assert.Equal(1, list.Count);
+    }
+
+    [Fact]
+    public void InsertAt_NegativeIndex_Throws()
+    {
+        var list = Create<int>();
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.InsertAt(-1, 1));
+    }
+
+    [Fact]
+    public void InsertAt_IndexGreaterThanCount_Throws()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.InsertAt(2, 2));
+    }
+
+    [Fact]
+    public void InsertAt_DuplicateItem_DoesNotThrowForOutOfRangeIndex()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        Assert.Throws<ArgumentOutOfRangeException>(() => list.InsertAt(5, 1));
+    }
+
+    [Fact]
+    public void InsertAt_MaintainsContainsConsistency()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(3);
+        list.InsertAt(1, 2);
+        Assert.True(list.Contains(1));
+        Assert.True(list.Contains(2));
+        Assert.True(list.Contains(3));
+    }
+
+    [Fact]
+    public void InsertAt_ThenRemove_Works()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(3);
+        list.InsertAt(1, 2);
+        list.Remove(2);
+        Assert.Equal(2, list.Count);
+        Assert.Equal(1, list[0]);
+        Assert.Equal(3, list[1]);
+    }
+
+    [Fact]
+    public void InsertAt_NearEnd_UsesBackwardTraversal()
+    {
+        // Test insertion near the end to exercise the backward traversal optimization
+        var list = Create<int>();
+        for (var i = 0; i < 20; i++)
+            list.Add(i * 2); // 0, 2, 4, ..., 38
+
+        // Insert at index 18 (near the end of 20 items)
+        Assert.True(list.InsertAt(18, 99));
+        Assert.Equal(21, list.Count);
+        Assert.Equal(34, list[17]);
+        Assert.Equal(99, list[18]);
+        Assert.Equal(36, list[19]);
+        Assert.Equal(38, list[20]);
+    }
+    #endregion
+
+    #region IndexOf
+    [Fact]
+    public void IndexOf_ExistingItem_ReturnsCorrectIndex()
+    {
+        var list = Create<int>();
+        list.Add(10);
+        list.Add(20);
+        list.Add(30);
+        Assert.Equal(0, list.IndexOf(10));
+        Assert.Equal(1, list.IndexOf(20));
+        Assert.Equal(2, list.IndexOf(30));
+    }
+
+    [Fact]
+    public void IndexOf_NonExistingItem_ReturnsNegativeOne()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        Assert.Equal(-1, list.IndexOf(99));
+    }
+
+    [Fact]
+    public void IndexOf_EmptyList_ReturnsNegativeOne()
+    {
+        var list = Create<int>();
+        Assert.Equal(-1, list.IndexOf(1));
+    }
+
+    [Fact]
+    public void IndexOf_AfterRemoval_ReturnsNegativeOne()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Remove(1);
+        Assert.Equal(-1, list.IndexOf(1));
+    }
+
+    [Fact]
+    public void IndexOf_AfterRemoval_UpdatesIndices()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        list.Remove(1);
+        Assert.Equal(0, list.IndexOf(2));
+        Assert.Equal(1, list.IndexOf(3));
+    }
+
+    [Fact]
+    public void IndexOf_WithCustomComparer_UsesComparer()
+    {
+        var list = HashList.Create<string>(StringComparer.OrdinalIgnoreCase, optimizeForRemove: true);
+        list.Add("Hello");
+        list.Add("World");
+        Assert.Equal(0, list.IndexOf("hello"));
+        Assert.Equal(1, list.IndexOf("WORLD"));
+    }
+
+    [Fact]
+    public void IndexOf_AfterInsertAt_ReturnsCorrectIndex()
+    {
+        var list = Create<int>();
+        list.Add(1);
+        list.Add(3);
+        list.InsertAt(1, 2);
+        Assert.Equal(0, list.IndexOf(1));
+        Assert.Equal(1, list.IndexOf(2));
+        Assert.Equal(2, list.IndexOf(3));
+    }
+
+    [Fact]
+    public void IndexOf_LargeList_ReturnsCorrectIndices()
+    {
+        var list = Create<int>();
+        for (var i = 0; i < 100; i++)
+            list.Add(i);
+        for (var i = 0; i < 100; i++)
+            Assert.Equal(i, list.IndexOf(i));
+    }
+    #endregion
+
     #region Large collection
     [Fact]
     public void LargeCollection_MaintainsInsertionOrder()

--- a/LaquaiLib.Collections.HashList.slnx
+++ b/LaquaiLib.Collections.HashList.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/Solution Items/">
+    <File Path=".gitignore" />
     <File Path="LICENSE" />
     <File Path="README.md" />
   </Folder>

--- a/LaquaiLib.Collections.HashList/ConcurrentHashList.cs
+++ b/LaquaiLib.Collections.HashList/ConcurrentHashList.cs
@@ -107,6 +107,31 @@ public sealed class ConcurrentHashList<T> : HashList<T>, IDisposable
         }
     }
 
+    public override bool InsertAt(int index, T item)
+    {
+        _rwls.EnterWriteLock();
+        try
+        {
+            return _inner.InsertAt(index, item);
+        }
+        finally
+        {
+            _rwls.ExitWriteLock();
+        }
+    }
+    public override int IndexOf(T item)
+    {
+        _rwls.EnterReadLock();
+        try
+        {
+            return _inner.IndexOf(item);
+        }
+        finally
+        {
+            _rwls.ExitReadLock();
+        }
+    }
+
     public override IEnumerator<T> GetEnumerator()
     {
         T[] snapshot;

--- a/LaquaiLib.Collections.HashList/ConcurrentHashList.cs
+++ b/LaquaiLib.Collections.HashList/ConcurrentHashList.cs
@@ -147,6 +147,81 @@ public sealed class ConcurrentHashList<T> : HashList<T>, IDisposable
         }
         return ((IEnumerable<T>)snapshot).GetEnumerator();
     }
+
+#if NET5_0_OR_GREATER
+    public override bool IsProperSubsetOf(IEnumerable<T> other)
+    {
+        _rwls.EnterReadLock();
+        try
+        {
+            return _inner.IsProperSubsetOf(other);
+        }
+        finally
+        {
+            _rwls.ExitReadLock();
+        }
+    }
+    public override bool IsProperSupersetOf(IEnumerable<T> other)
+    {
+        _rwls.EnterReadLock();
+        try
+        {
+            return _inner.IsProperSupersetOf(other);
+        }
+        finally
+        {
+            _rwls.ExitReadLock();
+        }
+    }
+    public override bool IsSubsetOf(IEnumerable<T> other)
+    {
+        _rwls.EnterReadLock();
+        try
+        {
+            return _inner.IsSubsetOf(other);
+        }
+        finally
+        {
+            _rwls.ExitReadLock();
+        }
+    }
+    public override bool IsSupersetOf(IEnumerable<T> other)
+    {
+        _rwls.EnterReadLock();
+        try
+        {
+            return _inner.IsSupersetOf(other);
+        }
+        finally
+        {
+            _rwls.ExitReadLock();
+        }
+    }
+    public override bool Overlaps(IEnumerable<T> other)
+    {
+        _rwls.EnterReadLock();
+        try
+        {
+            return _inner.Overlaps(other);
+        }
+        finally
+        {
+            _rwls.ExitReadLock();
+        }
+    }
+    public override bool SetEquals(IEnumerable<T> other)
+    {
+        _rwls.EnterReadLock();
+        try
+        {
+            return _inner.SetEquals(other);
+        }
+        finally
+        {
+            _rwls.ExitReadLock();
+        }
+    }
+#endif
     #endregion
 
     #region Extra functionality

--- a/LaquaiLib.Collections.HashList/HashList.cs
+++ b/LaquaiLib.Collections.HashList/HashList.cs
@@ -234,6 +234,21 @@ public abstract class HashList<T> : ICollection<T>, IReadOnlyList<T>
     public abstract T this[int index] { get; }
     #endregion
 
+    /// <summary>
+    /// Inserts <paramref name="item"/> at the specified <paramref name="index"/> in the list if it is not already present.
+    /// </summary>
+    /// <param name="index">The zero-based index at which to insert the item. Must be between 0 and <see cref="Count"/> (inclusive).</param>
+    /// <param name="item">The item to insert.</param>
+    /// <returns><see langword="true"/> if <paramref name="item"/> was not present and was inserted; <see langword="false"/> if it was already present.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="index"/> is less than 0 or greater than <see cref="Count"/>.</exception>
+    public abstract bool InsertAt(int index, T item);
+    /// <summary>
+    /// Returns the zero-based index of the first occurrence of <paramref name="item"/> in the list, or -1 if it is not present.
+    /// </summary>
+    /// <param name="item">The item to locate.</param>
+    /// <returns>The zero-based index of <paramref name="item"/> if found; otherwise, -1.</returns>
+    public abstract int IndexOf(T item);
+
     public abstract IEnumerator<T> GetEnumerator();
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }
@@ -278,6 +293,29 @@ internal sealed class DefaultListHashList<T> : HashList<T>
         throw new InvalidOperationException("Internal buffers were desynced.");
     }
     public override void CopyTo(T[] array, int arrayIndex) => _list.CopyTo(array, arrayIndex);
+    public override bool InsertAt(int index, T item)
+    {
+        if (index < 0 || index > _list.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), index, "Index must be within the bounds of the list or equal to Count for appending.");
+
+        if (!_set.Add(item))
+            return false;
+
+        _list.Insert(index, item);
+        return true;
+    }
+    public override int IndexOf(T item)
+    {
+        if (!_set.Contains(item))
+            return -1;
+
+        for (var i = 0; i < _list.Count; i++)
+            if (_comparer.Equals(_list[i], item))
+                return i;
+
+        Debug.Fail("Internal buffers were desynced");
+        throw new InvalidOperationException("Internal buffers were desynced.");
+    }
     public override bool Contains(T item) => _set.Contains(item);
     public override void Clear()
     {
@@ -337,6 +375,56 @@ internal sealed class LinkedListHashList<T>(int capacity, IEqualityComparer<T> e
         _map.Remove(item);
         _list.Remove(node);
         return true;
+    }
+    public override bool InsertAt(int index, T item)
+    {
+        if (index < 0 || index > _map.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), index, "Index must be within the bounds of the list or equal to Count for appending.");
+
+        if (_map.ContainsKey(item))
+            return false;
+
+        if (index == _map.Count)
+        {
+            _map[item] = _list.AddLast(item);
+        }
+        else if (index == 0)
+        {
+            _map[item] = _list.AddFirst(item);
+        }
+        else
+        {
+            // Navigate to the node at the target index, then insert before it
+            LinkedListNode<T> nodeAtIndex;
+            if (index > _map.Count >>> 1)
+            {
+                nodeAtIndex = _list.Last;
+                for (var i = _map.Count - 1; i > index; i--)
+                    nodeAtIndex = nodeAtIndex.Previous;
+            }
+            else
+            {
+                nodeAtIndex = _list.First;
+                for (var i = 0; i < index; i++)
+                    nodeAtIndex = nodeAtIndex.Next;
+            }
+            _map[item] = _list.AddBefore(nodeAtIndex, item);
+        }
+        return true;
+    }
+    public override int IndexOf(T item)
+    {
+        if (!_map.ContainsKey(item))
+            return -1;
+
+        var comparer = _map.Comparer;
+        var node = _list.First;
+        for (var i = 0; node is not null; i++, node = node.Next)
+            if (comparer.Equals(node.Value, item))
+                return i;
+
+        Debug.Fail("Internal buffers were desynced");
+        throw new InvalidOperationException("Internal buffers were desynced.");
     }
     public override bool Contains(T item) => _map.ContainsKey(item);
     public override void Clear()

--- a/LaquaiLib.Collections.HashList/HashList.cs
+++ b/LaquaiLib.Collections.HashList/HashList.cs
@@ -218,6 +218,9 @@ public sealed class HashListOptions<T>
 /// </summary>
 /// <typeparam name="T">The type of elements in the list.</typeparam>
 public abstract class HashList<T> : ICollection<T>, IReadOnlyList<T>
+#if NET5_0_OR_GREATER
+    , IReadOnlySet<T>
+#endif
 {
     #region ICollection<> impl
     public abstract bool Add(T item);
@@ -233,6 +236,18 @@ public abstract class HashList<T> : ICollection<T>, IReadOnlyList<T>
     #region IReadOnlyList<> impl
     public abstract T this[int index] { get; }
     #endregion
+
+#if NET5_0_OR_GREATER
+    #region IReadOnlySet<> impl
+
+    public abstract bool IsProperSubsetOf(IEnumerable<T> other);
+    public abstract bool IsProperSupersetOf(IEnumerable<T> other);
+    public abstract bool IsSubsetOf(IEnumerable<T> other);
+    public abstract bool IsSupersetOf(IEnumerable<T> other);
+    public abstract bool Overlaps(IEnumerable<T> other);
+    public abstract bool SetEquals(IEnumerable<T> other);
+    #endregion
+#endif
 
     /// <summary>
     /// Inserts <paramref name="item"/> at the specified <paramref name="index"/> in the list if it is not already present.
@@ -301,7 +316,15 @@ internal sealed class DefaultListHashList<T> : HashList<T>
         if (!_set.Add(item))
             return false;
 
-        _list.Insert(index, item);
+        try
+        {
+            _list.Insert(index, item);
+        }
+        catch
+        {
+            _set.Remove(item);
+            throw;
+        }
         return true;
     }
     public override int IndexOf(T item)
@@ -323,6 +346,15 @@ internal sealed class DefaultListHashList<T> : HashList<T>
         _list.Clear();
     }
     public override IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+
+#if NET5_0_OR_GREATER
+    public override bool IsProperSubsetOf(IEnumerable<T> other) => _set.IsProperSubsetOf(other);
+    public override bool IsProperSupersetOf(IEnumerable<T> other) => _set.IsProperSupersetOf(other);
+    public override bool IsSubsetOf(IEnumerable<T> other) => _set.IsSubsetOf(other);
+    public override bool IsSupersetOf(IEnumerable<T> other) => _set.IsSupersetOf(other);
+    public override bool Overlaps(IEnumerable<T> other) => _set.Overlaps(other);
+    public override bool SetEquals(IEnumerable<T> other) => _set.SetEquals(other);
+#endif
 }
 
 internal sealed class LinkedListHashList<T>(int capacity, IEqualityComparer<T> equalityComparer) : HashList<T>
@@ -384,14 +416,12 @@ internal sealed class LinkedListHashList<T>(int capacity, IEqualityComparer<T> e
         if (_map.ContainsKey(item))
             return false;
 
+        LinkedListNode<T> node;
+
         if (index == _map.Count)
-        {
-            _map[item] = _list.AddLast(item);
-        }
+            node = _list.AddLast(item);
         else if (index == 0)
-        {
-            _map[item] = _list.AddFirst(item);
-        }
+            node = _list.AddFirst(item);
         else
         {
             // Navigate to the node at the target index, then insert before it
@@ -408,7 +438,17 @@ internal sealed class LinkedListHashList<T>(int capacity, IEqualityComparer<T> e
                 for (var i = 0; i < index; i++)
                     nodeAtIndex = nodeAtIndex.Next;
             }
-            _map[item] = _list.AddBefore(nodeAtIndex, item);
+            node = _list.AddBefore(nodeAtIndex, item);
+        }
+
+        try
+        {
+            _map[item] = node;
+        }
+        catch
+        {
+            _list.Remove(node);
+            throw;
         }
         return true;
     }
@@ -433,4 +473,63 @@ internal sealed class LinkedListHashList<T>(int capacity, IEqualityComparer<T> e
         _list.Clear();
     }
     public override IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+
+#if NET5_0_OR_GREATER
+    public override bool IsProperSubsetOf(IEnumerable<T> other)
+    {
+        if (other is IReadOnlySet<T> ros)
+            return _map.Count < ros.Count && _map.Keys.All(ros.Contains);
+        if (_map.Count == 0)
+            return other.Any();
+        var s = new HashSet<T>(other, _map.Comparer);
+        return _map.Count < s.Count && _map.Keys.All(s.Contains);
+    }
+    public override bool IsProperSupersetOf(IEnumerable<T> other)
+    {
+        if (_map.Count == 0)
+            return false;
+        if (other is IReadOnlySet<T> ros)
+            return ros.Count < _map.Count && ros.All(i => _map.ContainsKey(i));
+        var seen = new HashSet<T>(_map.Comparer);
+        foreach (var item in other)
+        {
+            if (!_map.ContainsKey(item))
+                return false;
+            seen.Add(item);
+        }
+        return _map.Count > seen.Count;
+    }
+    public override bool IsSubsetOf(IEnumerable<T> other)
+    {
+        if (_map.Count == 0)
+            return true;
+        if (other is IReadOnlySet<T> ros)
+            return _map.Keys.All(ros.Contains);
+        var s = new HashSet<T>(other, _map.Comparer);
+        return _map.Keys.All(s.Contains);
+    }
+    public override bool IsSupersetOf(IEnumerable<T> other)
+    {
+        foreach (var item in other)
+            if (!_map.ContainsKey(item))
+                return false;
+        return true;
+    }
+    public override bool Overlaps(IEnumerable<T> other)
+    {
+        if (_map.Count == 0)
+            return false;
+        foreach (var item in other)
+            if (_map.ContainsKey(item))
+                return true;
+        return false;
+    }
+    public override bool SetEquals(IEnumerable<T> other)
+    {
+        if (other is IReadOnlySet<T> ros)
+            return ros.Count == _map.Count && _map.Keys.All(ros.Contains);
+        var s = new HashSet<T>(other, _map.Comparer);
+        return s.Count == _map.Count && _map.Keys.All(s.Contains);
+    }
+#endif
 }

--- a/LaquaiLib.Collections.HashList/HashList.cs
+++ b/LaquaiLib.Collections.HashList/HashList.cs
@@ -477,6 +477,9 @@ internal sealed class LinkedListHashList<T>(int capacity, IEqualityComparer<T> e
 #if NET5_0_OR_GREATER
     public override bool IsProperSubsetOf(IEnumerable<T> other)
     {
+        if (other is null)
+            throw new ArgumentNullException(nameof(other));
+
         if (other is IReadOnlySet<T> ros)
             return _map.Count < ros.Count && _map.Keys.All(ros.Contains);
         if (_map.Count == 0)
@@ -486,6 +489,9 @@ internal sealed class LinkedListHashList<T>(int capacity, IEqualityComparer<T> e
     }
     public override bool IsProperSupersetOf(IEnumerable<T> other)
     {
+        if (other is null)
+            throw new ArgumentNullException(nameof(other));
+
         if (_map.Count == 0)
             return false;
         if (other is IReadOnlySet<T> ros)
@@ -501,6 +507,9 @@ internal sealed class LinkedListHashList<T>(int capacity, IEqualityComparer<T> e
     }
     public override bool IsSubsetOf(IEnumerable<T> other)
     {
+        if (other is null)
+            throw new ArgumentNullException(nameof(other));
+
         if (_map.Count == 0)
             return true;
         if (other is IReadOnlySet<T> ros)
@@ -510,6 +519,9 @@ internal sealed class LinkedListHashList<T>(int capacity, IEqualityComparer<T> e
     }
     public override bool IsSupersetOf(IEnumerable<T> other)
     {
+        if (other is null)
+            throw new ArgumentNullException(nameof(other));
+
         foreach (var item in other)
             if (!_map.ContainsKey(item))
                 return false;
@@ -517,6 +529,9 @@ internal sealed class LinkedListHashList<T>(int capacity, IEqualityComparer<T> e
     }
     public override bool Overlaps(IEnumerable<T> other)
     {
+        if (other is null)
+            throw new ArgumentNullException(nameof(other));
+
         if (_map.Count == 0)
             return false;
         foreach (var item in other)
@@ -526,6 +541,9 @@ internal sealed class LinkedListHashList<T>(int capacity, IEqualityComparer<T> e
     }
     public override bool SetEquals(IEnumerable<T> other)
     {
+        if (other is null)
+            throw new ArgumentNullException(nameof(other));
+
         if (other is IReadOnlySet<T> ros)
             return ros.Count == _map.Count && _map.Keys.All(ros.Contains);
         var s = new HashSet<T>(other, _map.Comparer);

--- a/LaquaiLib.Collections.HashList/LaquaiLib.Collections.HashList.csproj
+++ b/LaquaiLib.Collections.HashList/LaquaiLib.Collections.HashList.csproj
@@ -18,7 +18,7 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IncludeSymbols>True</IncludeSymbols>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
 
     <PackageId>$(AssemblyName)</PackageId>
     <PackageVersion>$(Version)</PackageVersion>

--- a/LaquaiLib.Collections.HashList/LaquaiLib.Collections.HashList.csproj
+++ b/LaquaiLib.Collections.HashList/LaquaiLib.Collections.HashList.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <None Include="..\LICENSE;..\README.md;" Pack="True" PackagePath="/" />
+      <None Include="..\LICENSE;..\README.md" Pack="True" PackagePath="/" />
 
       <InternalsVisibleTo Include="$(AssemblyName).Tests" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `LaquaiLib.HashList`
+# `LaquaiLib.Collections.HashList`
 
 Implements a simple hash list, effectively a cross between some set data structure (to guarantee uniqueness of elements) and a list (to keep track of insertion order).
 


### PR DESCRIPTION
Add InsertAt(int index, T item) and IndexOf(T item) to HashList<T>, with implementations for both DefaultListHashList and LinkedListHashList strategies, plus thread-safe wrappers in ConcurrentHashList.

Closes #2, closes #3

https://claude.ai/code/session_01N9zHg8Jn7QRmNrG2ewGaPu